### PR TITLE
Fixing Data Storage issue

### DIFF
--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -118,7 +118,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     public final boolean useDedicatedTenancy;
 
-    public transient AMITypeData amiType;
+    public AMITypeData amiType;
 
     public int launchTimeout;
 
@@ -352,6 +352,14 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         this.ami = ami;
     }
 
+    public AMITypeData getAmiType() {
+        return amiType;
+    }
+
+    public void setAmiType(AMITypeData amiType) {
+        this.amiType = amiType;
+    }
+
     public int getInstanceCap() {
         return instanceCap;
     }
@@ -490,7 +498,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 riRequest.setInstanceInitiatedShutdownBehavior(ShutdownBehavior.Terminate);
                  logProvisionInfo(logger, "Setting Instance Initiated Shutdown Behavior : ShutdownBehavior.Terminate");
             }
-            
+
             List<Filter> diFilters = new ArrayList<Filter>();
             diFilters.add(new Filter("image-id").withValues(ami));
 


### PR DESCRIPTION
If EC2 instance doesn't expose AMITypeData, we effectively drop the data
in the AMITypeData object. For Windows slaves this means that the
password is removed and the instance type is defaulted to unix.